### PR TITLE
fix: skip push tags step if image tags have not been generated

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -206,11 +206,11 @@ jobs:
         if: inputs.push
         name: Push tags
         id: push
-        env:
-          IMAGE: ${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}
-          TAGS: ${{ join(fromJSON(steps.meta.outputs.json).tags, ' ') }}
         run: |
           echo "### Tags" >> $GITHUB_STEP_SUMMARY
+
+          export IMAGE='${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}'
+          export TAGS='${{ join(fromJSON(steps.meta.outputs.json).tags, ' ') }}'
 
           digest=""
           tags_stripped=""


### PR DESCRIPTION
Because environment variables defined for the step are evaluated before the conditionals for the step, push tags would fail when it should be skipped. Moving the variables into the script solves this.