### PR TITLE
Full image ref, tags and fix other outputs

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -81,6 +81,9 @@ on:
       image-ref-stripped:
         description: An image reference for this build, stripped of its registry URL ("<name>:<sha>@<digest>").
         value: ${{ jobs.push.outputs.image-ref-stripped }}
+      image-tags:
+        description: Comma-separated list of generated image tags for this build, (`<registry-url>/<name1>:<tag1>,<registry-url>/<name1>:<tag2>`).
+        value: ${{ jobs.push.outputs.image-tags }}
       image-tags-stripped:
         description: Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (i.e. "<name1>:<tag1>,<name2>:<tag2>").
         value: ${{ jobs.push.outputs.image-tags-stripped }}
@@ -231,6 +234,7 @@ jobs:
           export TAGS='${{ join(fromJSON(steps.meta.outputs.json).tags, ' ') }}'
 
           digest=""
+          tags=""
           tags_stripped=""
           for tag in $TAGS
           do
@@ -240,17 +244,18 @@ jobs:
             # every iteration, as they are all the same.
             digest=$(docker push $tag | tee | grep -oP 'digest: \K(sha256:[0-9a-f]*)')
 
-            # Collect all tags, stripped of their secrets, so that the workflow
-            # is allowed to use them as output.
+            # Collect all tags, both stripped of the registry URL and not.
+            tags+="${tag},"
             stripped=${tag#"${{ secrets.registry-url }}/"}
             tags_stripped+="${stripped},"
 
             # Add tag to summary output
-            echo "- \`<registry>/${stripped}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`${tag}\`" >> $GITHUB_STEP_SUMMARY
           done
           echo >> $GITHUB_STEP_SUMMARY
 
           # Remove trailing comma before setting as output var
+          echo "image-tags=$(echo "$tags" | sed 's|,*$||')" >> $GITHUB_OUTPUT
           echo "image-tags-stripped=$(echo "$tags_stripped" | sed 's|,*$||')" >> $GITHUB_OUTPUT
           echo "image-digest=${digest}" >> $GITHUB_OUTPUT
 
@@ -263,4 +268,5 @@ jobs:
     outputs:
       image-ref: ${{ inputs.registry-url }}/${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-ref-stripped: ${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
+      image-tags: ${{ steps.push.outputs.image-tags }}
       image-tags-stripped: ${{ steps.push.outputs.image-tags-stripped }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -246,7 +246,7 @@ jobs:
 
             # Collect all tags, both stripped of the registry URL and not.
             tags+="${tag},"
-            stripped=${tag#"${{ secrets.registry-url }}/"}
+            stripped=${tag#"${{ inputs.registry-url }}/"}
             tags_stripped+="${stripped},"
 
             # Add tag to summary output

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -77,16 +77,16 @@ on:
         value: ${{ jobs.build.outputs.image-digest }}
       image-ref:
         description: An image reference for this build (`<name>:<git-sha>@<digest>`).
-        value: ${{ jobs.push.outputs.image-ref }}
+        value: ${{ jobs.build.outputs.image-ref }}
       image-ref-stripped:
         description: An image reference for this build, stripped of its registry URL (`<name>:<git-sha>@<digest>`).
-        value: ${{ jobs.push.outputs.image-ref-stripped }}
+        value: ${{ jobs.build.outputs.image-ref-stripped }}
       image-tags:
         description: Comma-separated list of generated image tags for this build, (`<registry-url>/<name1>:<tag1>,<registry-url>/<name1>:<tag2>`).
-        value: ${{ jobs.push.outputs.image-tags }}
+        value: ${{ jobs.build.outputs.image-tags }}
       image-tags-stripped:
         description: Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (`<name1>:<tag1>,<name1>:<tag2>`).
-        value: ${{ jobs.push.outputs.image-tags-stripped }}
+        value: ${{ jobs.build.outputs.image-tags-stripped }}
       unique-id:
         description: A generated unique ID for this run. Can be useful when debugging runners to determine artifact filenames.
         value: ${{ jobs.build.outputs.unique-id }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,13 +79,13 @@ on:
         description: An image reference for this build (`<name>:<git-sha>@<digest>`).
         value: ${{ jobs.push.outputs.image-ref }}
       image-ref-stripped:
-        description: An image reference for this build, stripped of its registry URL ("<name>:<sha>@<digest>").
+        description: An image reference for this build, stripped of its registry URL (`<name>:<git-sha>@<digest>`).
         value: ${{ jobs.push.outputs.image-ref-stripped }}
       image-tags:
         description: Comma-separated list of generated image tags for this build, (`<registry-url>/<name1>:<tag1>,<registry-url>/<name1>:<tag2>`).
         value: ${{ jobs.push.outputs.image-tags }}
       image-tags-stripped:
-        description: Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (i.e. "<name1>:<tag1>,<name2>:<tag2>").
+        description: Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (`<name1>:<tag1>,<name1>:<tag2>`).
         value: ${{ jobs.push.outputs.image-tags-stripped }}
       unique-id:
         description: A generated unique ID for this run. Can be useful when debugging runners to determine artifact filenames.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -271,3 +271,4 @@ jobs:
       image-ref-stripped: ${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-tags: ${{ steps.push.outputs.image-tags }}
       image-tags-stripped: ${{ steps.push.outputs.image-tags-stripped }}
+      unique-id: ${{ steps.setup.outputs.unique-id }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -264,8 +264,9 @@ jobs:
           echo >> $GITHUB_STEP_SUMMARY
 
           echo "### Image reference" >> $GITHUB_STEP_SUMMARY
-          echo "- \`<registry>/${{ inputs.name }}:${{ github.sha }}@${digest}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ inputs.registry-url }}/${{ inputs.name }}:${{ github.sha }}@${digest}\`" >> $GITHUB_STEP_SUMMARY
     outputs:
+      image-digest: ${{ steps.push.outputs.image-digest }}
       image-ref: ${{ inputs.registry-url }}/${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-ref-stripped: ${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-tags: ${{ steps.push.outputs.image-tags }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -72,10 +72,12 @@ on:
         description: GitHub auth token.
         required: true
     outputs:
-      # TODO: add registry-url to image output
       image-digest:
         description: The image digest for this build.
         value: ${{ jobs.build.outputs.image-digest }}
+      image-ref:
+        description: An image reference for this build (`<name>:<git-sha>@<digest>`).
+        value: ${{ jobs.push.outputs.image-ref }}
       image-ref-stripped:
         description: An image reference for this build, stripped of its registry URL ("<name>:<sha>@<digest>").
         value: ${{ jobs.push.outputs.image-ref-stripped }}
@@ -259,5 +261,6 @@ jobs:
           echo "### Image reference" >> $GITHUB_STEP_SUMMARY
           echo "- \`<registry>/${{ inputs.name }}:${{ github.sha }}@${digest}\`" >> $GITHUB_STEP_SUMMARY
     outputs:
+      image-ref: ${{ inputs.registry-url }}/${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-ref-stripped: ${{ inputs.name }}:${{ github.sha }}@${{ steps.push.outputs.image-digest }}
       image-tags-stripped: ${{ steps.push.outputs.image-tags-stripped }}

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ jobs:
 
 ### Outputs
 - `image-digest` - The image digest for this build.
-- `image-ref-stripped` - An image reference for this build, stripped of its registry URL ("<name>:<sha>@<digest>").
-- `image-tags-stripped` - Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (i.e. "<name1>:<tag1>,<name2>:<tag2>").
+- `image-ref` - An image reference for this build (`<name>:<git-sha>@<digest>`).
+- `image-ref-stripped` - An image reference for this build, stripped of its registry URL (`<name>:<git-sha>@<digest>`).
+- `image-tags` - Comma-separated list of generated image tags for this build, (`<registry-url>/<name1>:<tag1>,<registry-url>/<name1>:<tag2>`).
+- `image-tags-stripped` - Comma-separated list of generated image tags for this build, stripped of their registry URL, without a leading slash (`<name1>:<tag1>,<name1>:<tag2>`).
 - `unique-id` - A generated unique ID for this run. Can be useful when debugging runners to determine artifact filenames.
 <!-- autodoc end -->
 


### PR DESCRIPTION
Seems to have fixed a whole list of bugs that I introduced a long time ago. Tested and working **almost** as intended:
- When consuming this workflow as it stands now, the `git.sha` used when tagging the built image **is not** the same sha as the last commit in the calling branch. Neither does it refer to a sha in this repository. A mystery!

[Tested in another repo](https://github.com/nrkno/plattform-go-akamai-datastream/actions/runs/5211735727).