### PR TITLE
feat: Add support for docker build-arg arguments.

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -93,6 +93,10 @@ on:
         type: boolean
         default: false
         description: Generate an SBOM of your dependencies and submit them to GitHub Dependency Graph.
+      build-args:
+        type: string
+        default: ""
+        description: Newline separated list of build arguments to pass to the Docker build.  
     secrets:
       git-ssh-key:
         description: SSH key used by Git to checkout the repository.
@@ -187,6 +191,7 @@ jobs:
           push: false
           pull: true
           tags: ${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}
+          build-args: ${{ inputs.build-args }}
           outputs: type=docker
       -
         if: inputs.cache == true && !inputs.ssh-agent
@@ -198,6 +203,7 @@ jobs:
           push: false
           pull: true
           tags: ${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}
+          build-args: ${{ inputs.build-args }}
           outputs: type=docker
           cache-from: type=registry,ref=${{ inputs.registry-url }}/${{ inputs.name }}:${{ inputs.cache-tag }}
           cache-to: type=registry,ref=${{ inputs.registry-url }}/${{ inputs.name }}:${{ inputs.cache-tag }},mode=max,ignore-error=true
@@ -211,6 +217,7 @@ jobs:
           push: false
           pull: true
           tags: ${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}
+          build-args: ${{ inputs.build-args }}          
           outputs: type=docker
           ssh: |
             default=${{ env.SSH_AUTH_SOCK }}
@@ -224,6 +231,7 @@ jobs:
           push: false
           pull: true
           tags: ${{ inputs.name }}:${{ steps.setup.outputs.unique-id }}
+          build-args: ${{ inputs.build-args }}
           outputs: type=docker
           cache-from: type=registry,ref=${{ inputs.registry-url }}/${{ inputs.name }}:${{ inputs.cache-tag }}
           cache-to: type=registry,ref=${{ inputs.registry-url }}/${{ inputs.name }}:${{ inputs.cache-tag }},mode=max,ignore-error=true

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ jobs:
 - `trivy-severity` (string, default `"MEDIUM,HIGH,CRITICAL"`) - Comma-separated list of severities to consider an error.
 - `trivy-summary-enabled` (boolean, default `false`) - Render a table of all the Trivy findings in the GitHub summary for the workflow.
 - `trivy-sbom-enabled` (boolean, default `false`) - Generate an SBOM of your dependencies and submit them to GitHub Dependency Graph.
+- `build-args` (string, default `""`) - Newline separated list of build arguments to pass to the Docker build.
 
 ### Secrets
 - `git-ssh-key` - SSH key used by Git to checkout the repository.


### PR DESCRIPTION
Adds support for passing dockre build-arg as argument. Will be used to pass version/commit hash as build-arg for the netbox build.  See https://github.com/docker/build-push-action#:~:text=setup%2Dbuildx%20action)-,build%2Dargs,-List

Example of use: https://github.com/nrkno/plattform-terraform-netbox-config/pull/810